### PR TITLE
Make `github` -> `GitHub`

### DIFF
--- a/gfmd/__main__.py
+++ b/gfmd/__main__.py
@@ -28,7 +28,7 @@ outline_client = OutlineApi(
 collection_id = os.environ["OUTLINE_COLLECTION_ID"]
 
 WARNING_HEADER = f""":::info
-This page is automatically synced from [github](https://github.com/{os.getenv('GITHUB_REPOSITORY')})
+This page is automatically synced from [GitHub](https://github.com/{os.getenv('GITHUB_REPOSITORY')})
 :::
 """
 


### PR DESCRIPTION
This pull request makes a slight tweak to the warning message shown at the top of all synced documents. It changes `github` to `GitHub`, as per the way it's written in GitHub's footer.

![image](https://user-images.githubusercontent.com/19637309/234515708-9b95b245-e898-48c4-9470-22689f3e0ea7.png)
